### PR TITLE
Added overload for error(message, {code, data}).

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,9 +102,9 @@ function jsend(config, host) {
 
 		if(typeof message === 'string') {
 			json.message = message;
-			if(rest) {
-				if(rest.code) json.code = rest.code;
-				if(rest.data) json.data = rest.data;
+			if(rest !== undefined) {
+				if(rest.code !== undefined) json.code = rest.code;
+				if(rest.data !== undefined) json.data = rest.data;
 			}
 		} else if(message && message.message) {
 			json.message = message.message;

--- a/index.js
+++ b/index.js
@@ -95,13 +95,17 @@ function jsend(config, host) {
 		};
 	}
 
-	function error(message) {
+	function error(message, rest) {
 		var json = {
 			status: 'error'
 		};
 
 		if(typeof message === 'string') {
 			json.message = message;
+			if(rest) {
+				if(rest.code) json.code = rest.code;
+				if(rest.data) json.data = rest.data;
+			}
 		} else if(message && message.message) {
 			json.message = message.message;
 			if(message.code !== undefined) json.code = message.code;

--- a/test/jsend.test.js
+++ b/test/jsend.test.js
@@ -367,6 +367,12 @@ describe('jsend', function() {
 				assert.deepEqual(json, jsendInstance.error(json));
 			});
 
+			it('with message as first argument, and data and code as second', function () {
+				var json = { status:'error', message:'something bad', code:'BAD_THINGS', data:{ foo:'bar' } };
+
+				assert.deepEqual(json, jsendInstance.error(json.message, {code: json.code, data: json.data}));
+			});
+
 			it('should throw error with no message', function() {
 				var json = { status:'error', code:'BAD_THINGS', data:{ foo:'bar' } };
 


### PR DESCRIPTION
Because message is always required, it would be convenient to type message directly, and pass code and/or data as part of a second argument object, i.e.:
`jsend.error('something bad', { code: 42 })`
rather than
`jsend.error({message: 'something bad', code: 42 })`
