### PR TITLE
return non-jsend responses as error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function jsend(config, host) {
 		else {
 			var err = new Error(json.message || ('Jsend response status: ' + json.status));
 			if('code' in json) err.code = json.code;
+			if('data' in json) err.data = json.data;
 			done(err, json.data);
 		}
 	}

--- a/test/jsend.test.js
+++ b/test/jsend.test.js
@@ -252,6 +252,22 @@ describe('jsend', function() {
 					jsendInstance.forward(json, assertCall(json, json.data));
 				});
 			});
+
+			describe('for invalid jsend responses', function() {
+				it('passes string responses back as the error message', function() {
+					var html = '<html><body>414 Request-URI Too Large</body></html>';
+					jsendInstance.forward(html, function(err, data) {
+						assert.equal(err.data.originalObject, html);
+					});
+				});
+
+				it('passes object responses back as the error message', function() {
+					var html = {"invalid-jsend": true};
+					jsendInstance.forward(html, function(err, data) {
+						assert.equal(err.data.originalObject["invalid-jsend"], html["invalid-jsend"]);
+					});
+				});
+			});
 		});
 
 		describe('- success', function() {


### PR DESCRIPTION
We keep running into problems with jsend.forward, in that any time a webserver returns a non-jsend response, the error response from jsend is rather unhelpful:

```json
{
  "status": "error",
  "message": "Invalid jsend object."
}
```

This situation nearly always occurs when the jsend service being called is having issues at the webserver level - a good example is in the tests of this PR.  This update changes the situation above to include the server response:
```json
{
  "status": "error",
  "message": "<html><body>414 Request-URI Too Large</body></html>"
}
```

imo, any non-jsend response is a violation of the contract with the server being called, and the response should be treated as an error & forwarded along.

@Prestaul thoughts?